### PR TITLE
解决 mac 10.9 下 生成的 ip-up 脚本不能运行

### DIFF
--- a/chnroutes.py
+++ b/chnroutes.py
@@ -70,7 +70,7 @@ def generate_mac(metric):
     #!/bin/sh
     export PATH="/bin:/sbin:/usr/sbin:/usr/bin"
     
-    OLDGW=`netstat -nr | grep '^default' | grep -v 'ppp' | sed 's/default *\\([0-9\.]*\\) .*/\\1/'`
+    OLDGW=`netstat -nr | grep '^default' | grep -v 'ppp' | sed 's/default *\\([0-9\.]*\\) .*/\\1/' | awk '{if($1){print $1}}'`
 
     if [ ! -e /tmp/pptp_oldgw ]; then
         echo "${OLDGW}" > /tmp/pptp_oldgw


### PR DESCRIPTION
OLDGW=`netstat -nr | grep '^default' | grep -v 'ppp' | sed 's/default
*\\([0-9\.]*\\) .*/\\1/' | awk '{if($1){print $1}}'`
去掉 oldgw 前面多余的空行
