### PR TITLE
chnroutes: Added support for darwin (mac's uname)

### DIFF
--- a/chnroutes.py
+++ b/chnroutes.py
@@ -249,7 +249,7 @@ if __name__=='__main__':
         generate_ovpn(args.metric)
     elif args.platform.lower() == 'linux':
         generate_linux(args.metric)
-    elif args.platform.lower() == 'mac':
+    elif args.platform.lower() == 'mac' or args.platform.lower() == 'darwin':
         generate_mac(args.metric)
     elif args.platform.lower() == 'win':
         generate_win(args.metric)


### PR DESCRIPTION
这个 PR 增加了对于 Mac 的 uname 输出 Darwin 的支持，使得 `-p "$(uname)"` 成为可能。
