### PR TITLE
linux: system wide static /etc/network/routes

### DIFF
--- a/chnroutes.py
+++ b/chnroutes.py
@@ -19,6 +19,17 @@ def generate_ovpn(metric):
           " and also add 'max-routes %d', which takes a line, to the head of the file." % (len(results)+20)
 
 
+def generate_routes(iface):
+    results = fetch_ip_data()  
+    rfile=open('routes','w')
+    for ip,mask,_ in results:
+        route_item="%s %s %s\n"%(ip,mask,iface)
+        rfile.write(route_item)
+    rfile.close()
+    print "Usage: Append the content of the newly created routes to /etc/network/routes," \
+          " total routes %d" % (len(results)+20)
+
+
 def generate_linux(metric):
     results = fetch_ip_data()
     upscript_header=textwrap.dedent("""\
@@ -195,6 +206,7 @@ def fetch_ip_data():
     #fetch data from apnic
     print "Fetching data from apnic.net, it might take a few minutes, please wait..."
     url=r'https://ftp.apnic.net/apnic/stats/apnic/delegated-apnic-latest'
+#   url=r'http://192.168.1.254/delegated-apnic-latest'
     data=urllib2.urlopen(url).read()
     
     cnregex=re.compile(r'apnic\|cn\|ipv4\|[0-9\.]+\|[0-9]+\|[0-9]+\|a.*',re.IGNORECASE)
@@ -247,6 +259,8 @@ if __name__=='__main__':
     
     if args.platform.lower() == 'openvpn':
         generate_ovpn(args.metric)
+    elif args.platform.lower() == 'routes':
+        generate_routes('___Interface___')
     elif args.platform.lower() == 'linux':
         generate_linux(args.metric)
     elif args.platform.lower() == 'mac' or args.platform.lower() == 'darwin':


### PR DESCRIPTION
please refer to:

https://askubuntu.com/questions/168033/how-to-set-static-routes-in-ubuntu-server
-----
There is a package ifupdown-extra avaible in Ubuntu.
It provides automatic scripts (installed in /etc/network/*/), one of which is used to add static routes.

The configuration file for this is  /etc/network/routes

The top of this config file has a good description:

This configuration file is read by the static-routes if-updown script and the /etc/init.d/networking-routes script to setup a list of routes associated either with a given interface or global routes.
An example route I use is:

192.168.240.0 255.255.255.0 192.168.130.3 em3
-----

How to use, in case your default gateway interface is 'enp0s29f7u2c4i2'

 $ python chnroutes.py -p routes
 $ sed -i 's/___Interface___/enp0s29f7u2c4i2/g' routes
 $
 $ # if you didn't have ifupdown-extra installed
 $ sudo apt-get install ifupdown-extra
 $
 $ sudo cat routes >>/etc/network/routes

this is a very draft commit, I don't know have any experience with
python. if any thing goes into issues, please help...

the routes will automatic added when the interface brings up, and also
removed when the interface is down or removed (usb hotspot or usb network
adapter).

the poster writen the nic as 'em3', I guess this maybe also works under
pfsense or *BSD gateways, never know.

Signed-off-by: Du Huanpeng <u74147@gmail.com>